### PR TITLE
pc/bt - revert version of spring-cloud-gateway-mvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ Storybook is here:
 * Production: <https://happycows.github.io/demo-spring-react-example-docs/>
 * QA:  <https://happycows.github.io/demo-spring-react-example-docs-qa/>
 
-The GitHub actions script to deploy the Storybook to QA requires that a repository secret called `TOKEN` be set up; this should be an access token for the repository.
+The GitHub actions script to deploy the Storybook to QA requires that a repository secret called `TOKEN` be set up; this should be an access token for the repository.   This secret can be obtained by visiting the settings page for either the organization, or a user with access to the organization, visiting Developer Settings, and then Personal Access Tokens. 
+
+![image](https://user-images.githubusercontent.com/1119017/147836507-0190801c-ce94-4e5a-9abe-6a1d2d0455af.png)
 
 
 # Test setup

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Storybook is here:
 * Production: <https://happycows.github.io/demo-spring-react-example-docs/>
 * QA:  <https://happycows.github.io/demo-spring-react-example-docs-qa/>
 
-
+The GitHub actions script to deploy the Storybook to QA requires that a repository secret called `TOKEN` be set up; this should be an access token for the repository.
 
 
 # Test setup

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-gateway-mvc</artifactId>
-            <version>3.1.0</version>
+            <version>3.0.1</version>
         </dependency>
         <dependency>
             <groupId>me.paulschwarz</groupId>


### PR DESCRIPTION
In this PR, we revert version of spring-cloud-gateway-mvc.

We were getting a problem where localhost:8080 would show a blank page in Chrome, and
an error about unsupported compression in Firefox.

Reverting version from 3.1.0 to 3.0.1 seems to fix it.