### PR TITLE
Update publish-docs-to-github-pages-qa.yml

### DIFF
--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -19,7 +19,7 @@ jobs:
           mkdir -p storybook-static
           npm run build-storybook
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.0
+        uses: JamesIves/github-pages-deploy-action@4.2.0
         with:
           repository-name: ${{ github.repository }}-docs-qa
           token: ${{ secrets.TOKEN }}


### PR DESCRIPTION
# Overview

Update publish-docs-to-github-pages-qa.yml to 4.2.0

# Issues Addressed

There is no formal GitHub issue filed (yet), but there is an  problem  with updating github pages, namely:

```
/usr/bin/git worktree add --no-checkout --detach github-pages-deploy-action-temp-deployment-folder
Preparing worktree (detached HEAD edbe791)
/usr/bin/git checkout --orphan main
fatal: A branch named 'main' already exists.
Running post deployment cleanup jobs… 🗑️
/usr/bin/git checkout -B github-pages-deploy-action/x94wwasky
Switched to a new branch 'github-pages-deploy-action/x94wwasky'
/usr/bin/chmod -R 777 github-pages-deploy-action-temp-deployment-folder
/usr/bin/git worktree remove github-pages-deploy-action-temp-deployment-folder --force
Error: The deploy step encountered an error: There was an error creating the worktree: The process '/usr/bin/git' failed with exit code 128 ❌ ❌
Deployment failed! ❌
```

