### PR TITLE
pc - try an alternative action for pushing to GitHub pages

### DIFF
--- a/.github/workflows/publish-docs-to-github-pages-qa.yml
+++ b/.github/workflows/publish-docs-to-github-pages-qa.yml
@@ -18,12 +18,12 @@ jobs:
           npm install
           mkdir -p storybook-static
           npm run build-storybook
+
       - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@4.1.0
+        uses: peaceiris/actions-gh-pages@v3
         with:
-          repository-name: ${{ github.repository }}-docs-qa
-          token: ${{ secrets.TOKEN }}
-          branch: main # The branch the action should deploy to.
-          folder: frontend/storybook-static # The folder that the build-storybook script generates files.
-          clean: true # Automatically remove deleted files from the deploy branch
-          target-folder: docs/storybook # The folder that we serve our Storybook files from 
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: frontend/storybook-static
+          destination_dir: docs/storybook
+          external_repository: ${{ github.repository }}-docs-qa
+          publish_branch: main  # default: gh-pages


### PR DESCRIPTION
# Overview

The GitHub action `JamesIves/github-pages-deploy-action@4.1.0` seems to have stopped working properly.  

In this PR, we are trying to substitute `peaceiris/actions-gh-pages@v3` to see if it works better.

# Issues Addressed

This error is what prompted this change:
```
/usr/bin/git worktree add --no-checkout --detach github-pages-deploy-action-temp-deployment-folder
Preparing worktree (detached HEAD edbe791)
/usr/bin/git checkout --orphan main
fatal: A branch named 'main' already exists.
Running post deployment cleanup jobs… 🗑️
/usr/bin/git checkout -B github-pages-deploy-action/x94wwasky
Switched to a new branch 'github-pages-deploy-action/x94wwasky'
/usr/bin/chmod -R 777 github-pages-deploy-action-temp-deployment-folder
/usr/bin/git worktree remove github-pages-deploy-action-temp-deployment-folder --force
Error: The deploy step encountered an error: There was an error creating the worktree: The process '/usr/bin/git' failed with exit code 128 ❌ ❌
Deployment failed! ❌
```