### PR TITLE
pc - add optional links for Swagger and the H2 Console 

### DIFF
--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -2,7 +2,8 @@ import { Button, Container, Nav, Navbar, NavDropdown } from "react-bootstrap";
 import { Link } from "react-router-dom";
 import { hasRole} from "main/utils/currentUser";
 
-export default function AppNavbar({currentUser, doLogout}) { 
+export default function AppNavbar({currentUser, systemInfo, doLogout}) { 
+  console.log("systemInfo",systemInfo);
   return (
     <Navbar expand="xl" variant="dark" bg="dark" sticky="top">
       <Container>
@@ -20,6 +21,23 @@ export default function AppNavbar({currentUser, doLogout}) {
                   <NavDropdown.Item href="/admin/users">Users</NavDropdown.Item>
                 </NavDropdown>
               )
+            }
+          </Nav>
+
+          <Nav className="me-auto">
+            {
+              systemInfo && systemInfo?.springH2ConsoleEnabled && (
+                <>
+                   <Nav.Link href="/h2-console">H2Console</Nav.Link>
+                </>
+              ) 
+            }
+            {
+              systemInfo && systemInfo?.showSwaggerUILink && (
+                <>
+                   <Nav.Link href="/swagger-ui/index.html">Swagger</Nav.Link>
+                </>
+              ) 
             }
           </Nav>
 

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -26,7 +26,7 @@ export default function AppNavbar({currentUser, systemInfo, doLogout}) {
 
           <Nav className="me-auto">
             {
-              systemInfo && systemInfo?.springH2ConsoleEnabled && (
+              systemInfo?.springH2ConsoleEnabled && (
                 <>
                    <Nav.Link href="/h2-console">H2Console</Nav.Link>
                 </>

--- a/frontend/src/main/layouts/BasicLayout/BasicLayout.js
+++ b/frontend/src/main/layouts/BasicLayout/BasicLayout.js
@@ -2,15 +2,18 @@ import { Container } from "react-bootstrap";
 import Footer from "main/components/Nav/Footer";
 import AppNavbar from "main/components/Nav/AppNavbar";
 import { useCurrentUser, useLogout} from "main/utils/currentUser";
+import { useSystemInfo} from "main/utils/systemInfo";
 
 export default function BasicLayout({ children }) {
 
   const { data: currentUser } = useCurrentUser();
+  const { data: systemInfo } = useSystemInfo();
+
   const doLogout = useLogout().mutate;
 
   return (
     <div className="d-flex flex-column min-vh-100">
-      <AppNavbar currentUser={currentUser} doLogout={doLogout} />
+      <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogout={doLogout} />
       <Container expand="xl" className="pt-4 flex-grow-1">
         {children}
       </Container>

--- a/frontend/src/main/utils/systemInfo.js
+++ b/frontend/src/main/utils/systemInfo.js
@@ -1,0 +1,18 @@
+import { useQuery } from "react-query";
+import axios from "axios";
+
+export function useSystemInfo() {
+  
+  return useQuery("systemInfo", async () => {
+    try {
+      const response = await axios.get("/api/systemInfo");
+      return response.data;
+    } catch (e) {
+      console.error("Error invoking axios.get: ", e);
+      return { error: true};
+    }
+  }, {
+    initialData: { initialData:true }
+  });
+
+}

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
@@ -12,19 +12,12 @@ public abstract class ApiController {
   @Autowired
   private CurrentUserService currentUserService;
 
-  @Autowired
-  private SystemInfoService systemInfoService;
-
   protected User getUser() {
     return currentUserService.getUser();
   }
 
   protected CurrentUser getCurrentUser() {
     return currentUserService.getCurrentUser();
-  }
-  
-  protected SystemInfo getSystemInfo() {
-    return systemInfoService.getSystemInfo();
   }
   
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
@@ -2,12 +2,18 @@ package edu.ucsb.cs156.example.controllers;
 
 import edu.ucsb.cs156.example.entities.User;
 import edu.ucsb.cs156.example.models.CurrentUser;
+import edu.ucsb.cs156.example.models.SystemInfo;
 import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.SystemInfoService;
+
 import org.springframework.beans.factory.annotation.Autowired;
 
 public abstract class ApiController {
   @Autowired
   private CurrentUserService currentUserService;
+
+  @Autowired
+  private SystemInfoService systemInfoService;
 
   protected User getUser() {
     return currentUserService.getUser();
@@ -15,6 +21,10 @@ public abstract class ApiController {
 
   protected CurrentUser getCurrentUser() {
     return currentUserService.getCurrentUser();
+  }
+  
+  protected SystemInfo getSystemInfo() {
+    return systemInfoService.getSystemInfo();
   }
   
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/SystemInfoController.java
@@ -1,26 +1,29 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.entities.User;
-import edu.ucsb.cs156.example.models.CurrentUser;
 import edu.ucsb.cs156.example.models.SystemInfo;
-import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.SystemInfoService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Api(description="System Information")
+@Api(description = "System Information")
 @RequestMapping("/api/systemInfo")
 @RestController
 public class SystemInfoController extends ApiController {
- 
-  @ApiOperation(value = "Get global information about the application")
-  @PreAuthorize("hasRole('ROLE_ADMIN')")
-  @GetMapping("")
-  public SystemInfo getSystemInfo() {
-    return super.getSystemInfo();
-  }
+
+    @Autowired
+    private SystemInfoService systemInfoService;
+
+    @ApiOperation(value = "Get global information about the application")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @GetMapping("")
+    public SystemInfo getSystemInfo() {
+        return systemInfoService.getSystemInfo();
+    }
+
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/SystemInfoController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/SystemInfoController.java
@@ -1,0 +1,26 @@
+package edu.ucsb.cs156.example.controllers;
+
+import edu.ucsb.cs156.example.entities.User;
+import edu.ucsb.cs156.example.models.CurrentUser;
+import edu.ucsb.cs156.example.models.SystemInfo;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(description="System Information")
+@RequestMapping("/api/systemInfo")
+@RestController
+public class SystemInfoController extends ApiController {
+ 
+  @ApiOperation(value = "Get global information about the application")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping("")
+  public SystemInfo getSystemInfo() {
+    return super.getSystemInfo();
+  }
+}

--- a/src/main/java/edu/ucsb/cs156/example/models/SystemInfo.java
+++ b/src/main/java/edu/ucsb/cs156/example/models/SystemInfo.java
@@ -1,0 +1,17 @@
+package edu.ucsb.cs156.example.models;
+
+import lombok.Data;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.Builder;
+import lombok.AccessLevel;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class SystemInfo {
+  private Boolean springH2ConsoleEnabled;
+  private Boolean showSwaggerUILink;
+}

--- a/src/main/java/edu/ucsb/cs156/example/services/SystemInfoService.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/SystemInfoService.java
@@ -1,0 +1,7 @@
+package edu.ucsb.cs156.example.services;
+
+import edu.ucsb.cs156.example.models.SystemInfo;
+
+public abstract class SystemInfoService {
+  public abstract SystemInfo getSystemInfo();
+}

--- a/src/main/java/edu/ucsb/cs156/example/services/SystemInfoServiceImpl.java
+++ b/src/main/java/edu/ucsb/cs156/example/services/SystemInfoServiceImpl.java
@@ -1,0 +1,29 @@
+package edu.ucsb.cs156.example.services;
+
+
+import edu.ucsb.cs156.example.models.SystemInfo;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+
+@Slf4j
+@Service("systemInfo")
+public class SystemInfoServiceImpl extends SystemInfoService {
+  
+  @Value("${spring.h2.console.enabled:false}")
+  private boolean springH2ConsoleEnabled;
+
+  @Value("${app.showSwaggerUILink:false}")
+  private boolean showSwaggerUILink;
+
+  public SystemInfo getSystemInfo() {
+    SystemInfo si = SystemInfo.builder()
+    .springH2ConsoleEnabled(this.springH2ConsoleEnabled)
+    .showSwaggerUILink(this.showSwaggerUILink)
+    .build();
+  log.info("getSystemInfo returns {}",si);
+  return si;
+  }
+
+}

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -1,6 +1,8 @@
 logging.level.sql=DEBUG
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 spring.datasource.url=jdbc:h2:file:./target/db-development
+spring.datasource.username=sa
+spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
 app.showSwaggerUILink=true

--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -3,3 +3,4 @@ logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 spring.datasource.url=jdbc:h2:file:./target/db-development
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
+app.showSwaggerUILink=true


### PR DESCRIPTION


# Overview

In this PR, we make it so that on localhost, the user can typically see
links for the H2 console and for SwaggerUI.

This is done by:

* creating a backend controller/service to provide overall global system information (typically values from the properties files)
* adding a new utility in the front end to get this backend info (a hook `useSystemInfo`, and passing that info to the `AppNavbar`
* using the `systemInfo` values to check whether H2 is enabled, and whether the property `app.showSwaggerUILink` is true, and using those values to conditionally add links to the Navbar.

